### PR TITLE
Updated responses to match Wagtail 4 chooser names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     install_requires=[
         "Django>=3.2,<4.2",
-        "Wagtail>=2.15,<4.1",
+        "Wagtail>=4.0",
     ],
     extras_require={
         "testing": ["dj-database-url==0.5.0", "freezegun==0.3.15"],

--- a/wagtail_hallo/static/js/hallo-plugins/hallo-wagtaildoclink.js
+++ b/wagtail_hallo/static/js/hallo-plugins/hallo-wagtaildoclink.js
@@ -31,7 +31,7 @@
           url: window.chooserUrls.documentChooser,
           onload: DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS,
           responses: {
-            documentChosen: function (docData) {
+            chosen: function (docData) {
               var link;
 
               link = document.createElement('a');

--- a/wagtail_hallo/static/js/hallo-plugins/hallo-wagtailimage.js
+++ b/wagtail_hallo/static/js/hallo-plugins/hallo-wagtailimage.js
@@ -35,7 +35,7 @@
           url: window.chooserUrls.imageChooser + '?select_format=true',
           onload: IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
           responses: {
-            imageChosen: function (imageData) {
+            chosen: function (imageData) {
               var elem;
 
               elem = $(imageData.html).get(0);


### PR DESCRIPTION
Fixes #33 

However, changing these 2 lines means at this point, the code is no longer agnostic between Wagtail 3 and 4. @lb- I don't know a trick like the try/catch for python imports that would allow this to work on both sets. Should we create a pypi release with the previous code (and stating Wagtail <= 3) and then merge this and declare this Wagtail 4+? If so, should we go ahead and remove the ifs in the imports? 

(I have tested this fix and it works on Wagtail 4.0 and 4.1)